### PR TITLE
Add IDs section to API doc

### DIFF
--- a/apis.md
+++ b/apis.md
@@ -20,7 +20,7 @@ HuBMAP uses three different kinds of IDs:
 - Example: `10.1234/HBM123.ABCD.456` 
 - Used for referencing outside HuBMAP context, in particular in publications.
 - Displayed as: doi:10.1234/HBM.123.ABCD.456
-- Linked to: https://doi.org/10.1234/HBM.123.ABCD.456
+- Linked to: `https://doi.org/10.1234/HBM.123.ABCD.456`
 - 1:1 mapping to HuBMAP ID
 
 

--- a/apis.md
+++ b/apis.md
@@ -1,4 +1,30 @@
-# HuBMAP Application Programmer Interfaces (APIs)
+# HuBMAP IDs and APIs
+
+## IDs
+
+HuBMAP uses three different kinds of IDs:
+
+### HuBMAP ID
+- Example: `HBM123.ABCD.456` 
+- Used for identification of HuBMAP entities and referencing in HuBMAP context, e.g. in the portal UI, slides, human-human communication, etc.
+- Can be used to query portal UI and APIs
+- 1:1 mapping to UUID
+
+### UUID
+- Example: `0123456789abcdef0123456789abcdef`
+- Used for software implementation
+- Can be used to query portal UI and API
+- 1:1 mapping to HuBMAP ID
+
+### DOI
+- Example: `10.1234/HBM123.ABCD.456` 
+- Used for referencing outside HuBMAP context, in particular in publications.
+- Displayed as: doi:10.1234/HBM.123.ABCD.456
+- Linked to: https://doi.org/10.1234/HBM.123.ABCD.456
+- 1:1 mapping to HuBMAP ID
+
+
+## APIs
 Five application programming interfaces (APIs) currently define 
 data ingest support: Ingest, UUID, Search & Index, Entity, and Ontology.  Additionally, the HuBMAP portal uses Common Coordinate Framework (CCF) APIs (created by Indiana University TC) and internal transformation APIs (created by Harvard University TC)
 

--- a/apis.md
+++ b/apis.md
@@ -19,9 +19,9 @@ HuBMAP uses three different kinds of IDs:
 ### DOI
 - Example: `10.1234/HBM123.ABCD.456` 
 - Used for referencing outside HuBMAP context, in particular in publications.
-- Displayed as: doi:10.1234/HBM.123.ABCD.456
+- Displayed as: `doi:10.1234/HBM.123.ABCD.456`
 - Linked to: `https://doi.org/10.1234/HBM.123.ABCD.456`
-- 1:1 mapping to HuBMAP ID
+- Not all HuBMAP IDs are registered as DOIs.
 
 
 ## APIs


### PR DESCRIPTION
Copy and paste ID info from google doc. Prepending to API info seems like its a place where the intended audience would notice it. Rereading, I notice that the statement for DOI: "1:1 mapping to HuBMAP ID" isn't really true. A string may structurally look like DOI, but it won't work unless it's been registered. I'll try to rephrase that...