### PR TITLE
Document feedback process

### DIFF
--- a/feedback.md
+++ b/feedback.md
@@ -1,0 +1,33 @@
+# User Feedback
+
+Feedback about the portal comes through multiple channels, including:
+- [the contact form](https://hubmapconsortium.org/contact-us/),
+- the [feedback email](mailto:help@hubmapconsortium.org) link in the footer,
+- [directly in github](https://github.com/hubmapconsortium/portal-ui/issues/new/choose),
+- and periodic user surveys.
+
+Tags are used to identify issues associated with different phases of the project:
+- [Alpha](https://github.com/hubmapconsortium/portal-ui/issues?q=is%3Aopen+is%3Aissue+label%3AAlpha)
+- [Beta](https://github.com/hubmapconsortium/portal-ui/issues?q=is%3Aopen+is%3Aissue+label%3ABeta)
+
+## Process
+
+- Feedback is first processed by the IEC, and user account and globus issues are handled there.
+- If the problem concerns the Portal an issue is then filed in github with the
+  [`triage`](https://github.com/hubmapconsortium/portal-ui/issues?q=is%3Aopen+is%3Aissue+label%3Atriage) tag.
+- A Portal developer reviews it, and may
+    - split it up into more fine-grained issues,
+    - note existing issues that cover the same ground,
+    - add notes to the issue clarifying the work to be done,
+    - or move it to a diffent repo, for instance [`portal-docs`](https://github.com/hubmapconsortium/portal-docs/issues).
+- At this point either the `triage` tag is removed, and it is treated like any other internal issue,
+  or it is [closed](https://github.com/hubmapconsortium/portal-ui/issues?q=is%3Aissue+label%3Atriage+is%3Aclosed).
+- Current work items are tracked with
+  [milestones](https://github.com/hubmapconsortium/portal-ui/issues?q=is%3Aissue+milestone%3A%2A+is%3Aopen).
+- Tags are used to identify issues that are not moving forward. Possible reasons include:
+    - Waiting to see if more people complain:
+      [`on-hold`](https://github.com/hubmapconsortium/portal-ui/issues?q=is%3Aopen+is%3Aissue+label%3Aon-hold)
+    - Prerequisites not in place:
+      [`blocked`](https://github.com/hubmapconsortium/portal-ui/issues?q=is%3Aopen+is%3Aissue+label%3Ablocked)
+    - Not feasible, or just not a good idea:
+      [`wontfix`](https://github.com/hubmapconsortium/portal-ui/issues?q=is%3Aopen+is%3Aissue+label%3Awontfix)


### PR DESCRIPTION
Document the feedback process. This is pretty ugly... but I am pretty sure adding a project board would increase the work and the complexity, not lessen it. That said, I'm not sure I understand the underlying information need, so there might be something more focused we could deliver.

- Is someone at NIH particularly concerned about what happened with their particular feedback? They'd be better off just filing a github issue, instead of going through IEC.
- Is someone trying to get an overview? I think it's impossible not to miss the forest for the trees looking at issue lists, in any form.
- Are they looking at the ultimate disposition of issues that came from "Outside"? We take the triage tag off after they are triaged... I suppose you could look for issues authored by IEC, but that's indirect.
